### PR TITLE
feat: 新增配置项，允许高亮展示目标 view 的父 view

### DIFF
--- a/app/src/main/java/com/demo/aty/SimpleGuideViewActivity.java
+++ b/app/src/main/java/com/demo/aty/SimpleGuideViewActivity.java
@@ -67,7 +67,8 @@ public class SimpleGuideViewActivity extends Activity {
     final GuideBuilder builder1 = new GuideBuilder();
     builder1.setTargetView(ll_nearby)
             .setAlpha(150)
-            .setHighTargetGraphStyle(Component.CIRCLE);
+            .setHighTargetGraphStyle(Component.ROUNDRECT)
+            .setIsHighlightParent(true);
     builder1.setOnVisibilityChangedListener(new GuideBuilder.OnVisibilityChangedListener() {
       @Override
       public void onShown() {

--- a/guideview/src/main/java/com/binioter/guideview/Configuration.java
+++ b/guideview/src/main/java/com/binioter/guideview/Configuration.java
@@ -90,6 +90,11 @@ class Configuration implements Parcelable {
 
   int mExitAnimationId = -1;
 
+  /**
+   * 是否高亮显示父 view
+   */
+  boolean mIsHighlightShowParent = false;
+
   @Override
   public int describeContents() {
     return 0;
@@ -110,6 +115,7 @@ class Configuration implements Parcelable {
     dest.writeInt(mGraphStyle);
     dest.writeByte((byte) (mAutoDismiss ? 1 : 0));
     dest.writeByte((byte) (mOverlayTarget ? 1 : 0));
+    dest.writeByte((byte) (mIsHighlightShowParent ? 1 : 0));
   }
 
   public static final Creator<Configuration> CREATOR = new Creator<Configuration>() {
@@ -129,6 +135,7 @@ class Configuration implements Parcelable {
       conf.mGraphStyle = source.readInt();
       conf.mAutoDismiss = source.readByte() == 1;
       conf.mOverlayTarget = source.readByte() == 1;
+      conf.mIsHighlightShowParent = source.readByte() == 1;
       return conf;
     }
 

--- a/guideview/src/main/java/com/binioter/guideview/Guide.java
+++ b/guideview/src/main/java/com/binioter/guideview/Guide.java
@@ -198,12 +198,24 @@ public class Guide implements View.OnKeyListener, View.OnTouchListener {
         }
 
         if (mConfiguration.mTargetView != null) {
-            maskView.setTargetRect(Common.getViewAbsRect(mConfiguration.mTargetView, parentX, parentY));
+            if (mConfiguration.mIsHighlightShowParent &&
+                    mConfiguration.mTargetView.getParent() != null) {
+                maskView.setTargetRect(Common.getViewAbsRect((View) mConfiguration.mTargetView.getParent(),
+                        parentX, parentY));
+            } else {
+                maskView.setTargetRect(Common.getViewAbsRect(mConfiguration.mTargetView, parentX, parentY));
+            }
         } else {
             // Gets the target view's abs rect
             View target = activity.findViewById(mConfiguration.mTargetViewId);
             if (target != null) {
-                maskView.setTargetRect(Common.getViewAbsRect(target, parentX, parentY));
+                if (mConfiguration.mIsHighlightShowParent &&
+                        target.getParent() != null) {
+                    maskView.setTargetRect(Common.getViewAbsRect((View) target.getParent(),
+                            parentX, parentY));
+                } else {
+                    maskView.setTargetRect(Common.getViewAbsRect(target, parentX, parentY));
+                }
             }
         }
 

--- a/guideview/src/main/java/com/binioter/guideview/GuideBuilder.java
+++ b/guideview/src/main/java/com/binioter/guideview/GuideBuilder.java
@@ -323,6 +323,19 @@ public class GuideBuilder {
     }
 
     /**
+     * 是否高粱展示父 view
+     *
+     * @return GuideBuilder
+     */
+    public GuideBuilder setIsHighlightParent(boolean isHighlightParent) {
+        if (mBuilt) {
+            throw new BuildException("Already created. rebuild a new one.");
+        }
+        mConfiguration.mIsHighlightShowParent = isHighlightParent;
+        return this;
+    }
+
+    /**
      * 创建Guide，非Fragment版本
      *
      * @return Guide


### PR DESCRIPTION
作者你好，这个新手引导的库非常实用，但在使用过程中，有遇到需求预期高亮 ViewGroup 中的某一个 View，如果通过计算展示蒙层信息的 view 会存在兼容性问题（不能全机型覆盖）
查询代码后发现，如果可以暴露一个配置项，允许高亮展示 targetView 的父 View，那么就可以避免过多复杂的计算，在 demo SimpleGuideViewActivity 中简单验证通过，希望可以帮助到其他人。